### PR TITLE
prep for 10.8/2.5 git tag and npm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.5.0] - 2019-11-18
+
+### Added
+
+* ArcGIS 2.5 / 10.8 codes
+
 ## [2.3.0] - 2018-02-13
 
 ### Added
@@ -19,5 +25,6 @@ All notable changes to this project will be documented in this file.
 
 * ArcGIS 2.1 / 10.6.0 codes
 
+[2.5.0]: https://github.com/Esri/projection-engine-db-doc/compare/v2.3.0...v2.5.0
 [2.3.0]: https://github.com/Esri/projection-engine-db-doc/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Esri/projection-engine-db-doc/compare/v2.1.0...v2.2.0

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Documentation files are found in the following directories:
            <li> nad/esri
            <li> nad/esri_extra
         </ul>
-       
+
    <li>Area extents are specified in degrees (from Greenwich).
 
    <li>Accuracy values in transformation entries are specified in meters.
@@ -81,7 +81,7 @@ an issue.
 
 ### Licensing
 
-Copyright &copy; 2010-2019 Esri
+Copyright &copy; 2010-2020 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/json/README.md
+++ b/json/README.md
@@ -60,7 +60,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ## Licensing
 
-Copyright &copy; 2010-2019 Esri
+Copyright &copy; 2010-2020 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/json/package-lock.json
+++ b/json/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/proj-codes",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/json/package.json
+++ b/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/proj-codes",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "description": "Get WKT and other metadata associated with an Esri/EPSG factory code.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
greetings! 👋 

i just noticed that the [npm package](https://www.npmjs.com/package/@esri/proj-codes) i created for JS developers to fetch information about ArcGIS Projections is getting 700+ downloads a week, but it hasn't been updated in ~a year.

here's what is needed to get that module distribution up to date.

1. review/merge this PR
2. run the commands below
```bash
git checkout master
git pull origin master
git tag v2.5.0
git push origin master --follow-tags
```
afterward someone with access to the @esri namespace on npm (like @rgwozdz) will need to run a few more commands.
```bash
git checkout master
git pull origin master
cd json
npm publish
```

the git tag isn't strictly necessary to publish work on npm, but its considered best practice to refer folks to a specific SHA and not ask them to trawl through your repo's history.

to that end, its also possible to tag and publish from 0d2c4e48af970d322baf393fd9b9e9b64c67727c directly if you want to advertise _exactly_ what shipped with that version of the software and omit the small fixes that landed here afterward if you'd prefer.

if y'all are interested in creating a belated tag and corresponding 10.7.1 release too, just say the word. it's definitely doable, it'd just require a little more `git` 🤸 .